### PR TITLE
{msh_ply} Add assert.h to MSH_PLY_INCLUDE_LIBC_HEADERS

### DIFF
--- a/msh_ply.h
+++ b/msh_ply.h
@@ -224,6 +224,7 @@
   DEPENDENCIES
 
     This file requires following c stdlib headers:
+    - assert.h
     - stdlib.h
     - stdint.h
     - string.h
@@ -267,6 +268,7 @@
 #define MSH_PLY
 
 #if defined(MSH_PLY_INCLUDE_LIBC_HEADERS)
+#include <assert.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
Fixes warning (or error if using -Werror):

> error: implicit declaration of function 'assert' is invalid in C99 [-Werror,-Wimplicit-function-declaration]

Apple clang version 14.0.0 (clang-1400.0.29.202)